### PR TITLE
Migrate Fiddle in README from RawGit to jsDelivr

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ I've tried to select a diverse range of browsers and platforms for maximum cover
 
 ## Usage
 
-Decl is designed to be intuitive and reminiscent of SCSS. To get an intuition for how Decl works, check out [this Fiddle](https://jsfiddle.net/wtzp3xz1/) which shows a simple implementation for the accordion effect.
+Decl is designed to be intuitive and reminiscent of SCSS. To get an intuition for how Decl works, check out [this Fiddle](https://jsfiddle.net/wdvfghty/) which shows a simple implementation for the accordion effect.
 
 ### Scopes
 


### PR DESCRIPTION
The example Fiddle in the README no longer works properly because [RawGit has been shutdown](https://rawgit.com/). This switches the Fiddle to a new version which uses [jsDelivr](https://www.jsdelivr.com/rawgit) instead.

As a bonus, hopefully a recent commit will make all the badges work again (assuming the build process is modern enough to still run :crossed_fingers:).